### PR TITLE
Remove usage localStorage

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -35,11 +35,11 @@ const checkout = new CheckoutAPI(client);
 
 // Invoke /sessions endpoint
 app.post("/api/sessions", async (req, res) => {
-  const localhost = req.get('host');
+
   try {
     // Unique ref for the transaction
     const orderRef = uuid();
-
+    // Determine host (for setting returnUrl)
     const protocol = req.socket.encrypted? 'https' : 'http';
     const host = req.get('host');
 


### PR DESCRIPTION
`clientKey` and `sessionId` are saved on localStorage every time the user loads the `drop-in`. When performing a second payment (after a successful one) the existing `sessionId` is re-used causing an error during the initialization of the Web `drop-in`.

This PR refactors the approach to avoid storing `clientKey` and `sessionId` on localStorage: clientKey is always available (no need to save it on localStorage), sessionId is read from the URL parameters (similarly as all other sample apps)