### PR TITLE
Update Dependabot config (skip '_archive/**')

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,20 @@
 version: 2
 updates:
-- package-ecosystem: "npm" 
-    directory: "/" 
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: "weekly" 
+      interval: "weekly"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch", "version-update:semver-minor"]
-- package-ecosystem: "npm" 
-    directory: "/" 
+    ignore-paths:
+      - "_archive/**"
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: "daily" 
+      interval: "daily"
     allow:
       - dependency-name: "@adyen/api-library"
+    ignore-paths:
+      - "_archive/**"
       


### PR DESCRIPTION
This PR updates the Dependabot configuration to skip dependency changes in `_archive/**` folder